### PR TITLE
Add flake.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Recommended to use [py3_sg](https://github.com/tvladyslav/py3_sg) on Linux to ac
 
 There's a very experimental [pyusb](https://github.com/pyusb/pyusb/) backend, but it is pretty unreliable especially (it seems) on some UAS-enabled firmwares... :|
 
+Or if you [install Nix](https://github.com/DeterminateSystems/nix-installer?tab=readme-ov-file#the-determinate-nix-installer) you can run it like this e.g.:
+
+```
+$ nix run github:projectgus/jms567ctl -- --help
+```
+
 ## Commands
 
 ### Read firmware version

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,63 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1704152458,
+        "narHash": "sha256-DS+dGw7SKygIWf9w4eNBUZsK+4Ug27NwEWmn2tnbycg=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "88a2cd8166694ba0b6cb374700799cec53aef527",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-parts",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1704538339,
+        "narHash": "sha256-1734d3mQuux9ySvwf6axRWZRBhtcZA9Q8eftD6EZg6U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "46ae0210ce163b3cba6c7da08840c1d63de9c701",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1703961334,
+        "narHash": "sha256-M1mV/Cq+pgjk0rt6VxoyyD+O8cOUiai8t9Q6Yyq4noY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b0d36bd0a420ecee3bc916c91886caca87c894e9",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,43 @@
+{
+  description = "Flashing tool for JMicron JMS567";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      debug = true;
+      imports = [];
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      perSystem = { self', config, pkgs, system, ... }: {
+        packages.default =
+          let
+            py3sg = pkgs.python3.pkgs.buildPythonPackage {
+              pname = "py3sg";
+              version = "";
+              src = pkgs.fetchFromGitHub {
+                owner = "tvladyslav";
+                repo = "py3_sg";
+                rev = "524492b11a6218841cc2d4fe8246bbf1e5674392";
+                sha256 = "sha256-wISc8OmycAJmRmqeLXP4zba210BoHTrlrIf6VdLswtE=";
+              };
+            };
+            python = pkgs.python3.withPackages (p: [
+              p.pyusb
+              py3sg
+            ]);
+            jms567ctl_py = builtins.path {
+              name = "jms567ctl.py";
+              path = ./jms567ctl.py;
+            };
+          in
+          pkgs.writeShellScriptBin "jms567ctl.sh" ''
+            ${python}/bin/python3 ${jms567ctl_py} "$@"
+          '';
+      };
+    };
+}


### PR DESCRIPTION
Hi and thanks for this project!

I have one of [these SSK enclosures](https://www.amazon.co.uk/gp/product/B07TXCMQ8B/), but speed was abysmal even though the SSD in it is pretty fast. I thought it might be the firmware so I tried some Windows tools but they all said the firmware was up to date.
BTW `lsusb -v` says this is a JMS567 even though the amazon listing says it's a RTL9210B :man_shrugging: 

Anyway I ended up finding this project. But setting up the Python environment for it is a hassle, so I wrote this flake.nix.

In case you're not familiar with [Nix](https://nixos.org/), in short anyone can [install it](https://github.com/DeterminateSystems/nix-installer?tab=readme-ov-file#the-determinate-nix-installer) and then run this project with `nix run github:mausch/jms567ctl -- --help` without installing anything else or needing to know anything about Python or pip or any of that.
(you can replace `mausch` with `projectgus` if you merge this)

In the end my problem was caused by the cable not the firmware :man_facepalming: , so I didn't write any new firmware but I did read the current firmware and it worked fine so writing should work too I think.
